### PR TITLE
fix: mixed case custom callout types are supported

### DIFF
--- a/src/callout/manager.ts
+++ b/src/callout/manager.ts
@@ -204,12 +204,12 @@ export default class CalloutManager extends Component {
                 ? `--callout-color: ${admonition.color};`
                 : "";
         if (admonition.icon.type == "obsidian") {
-            rule = `.callout[data-callout="${admonition.type}"] {
+            rule = `.callout[data-callout="${admonition.type.toLowerCase()}"] {
     ${color}
     --callout-icon: ${admonition.icon.name};  /* Icon name from the Obsidian Icon Set */
 }`;
         } else {
-            rule = `.callout[data-callout="${admonition.type}"] {
+            rule = `.callout[data-callout="${admonition.type.toLowerCase()}"] {
        ${color}
         --callout-icon: '${(
             this.plugin.iconManager.getIconNode(admonition.icon)?.outerHTML ??


### PR DESCRIPTION
This has at least been a bug since #252.

Custom admonition types that include uppercase letters do not work with callouts. Callouts are *always* rendered with a lowercase type, for example:

```markdown
> [!Exercise] Sharpen your pencil
> My custom callout!
```

Is rendered in html as:
```html
<div data-callout-metadata="" data-callout-fold="" data-callout="exercise" class="callout"><div class="callout-title">
```

So unless the custom admonition type is lowercase, the css snippet won't work and the default callout styles are used. This change simply converts the type to lowercase before updating the css snippet.