### PR TITLE
fix: use custom title in InsertAdmonitionModal

### DIFF
--- a/src/modal/index.ts
+++ b/src/modal/index.ts
@@ -439,6 +439,7 @@ export class InsertAdmonitionModal extends Modal {
                     this.plugin.admonitions[t.inputEl.value]
                 ) {
                     this.type = t.inputEl.value;
+                    this.title = this.plugin.admonitions[this.type].title;
                     if (!this.title?.length) {
                         this.title =
                             this.type[0].toUpperCase() +


### PR DESCRIPTION
When a title is set on a custom admonition, it should be the default title when inserting an admonition of that type. However, the value is never actually updated on the modal. This commit updates the title when an admonition type is selected.