### PR TITLE
🐛 normalize callout type to lowercase in calloutProcessor

### DIFF
--- a/ad-test-vault/01-basic-options.md
+++ b/ad-test-vault/01-basic-options.md
@@ -8,6 +8,10 @@ The admonition type name becomes the title (capitalized).
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ```
 
+```ad-Note
+case-insensitive admonition name
+```
+
 ---
 
 ## title: — Custom title

--- a/src/callout/manager.ts
+++ b/src/callout/manager.ts
@@ -43,11 +43,14 @@ export default class CalloutManager extends Component {
     calloutProcessor(el: HTMLElement, ctx: MarkdownPostProcessorContext) {
         const callout = el?.querySelector<HTMLDivElement>(".callout");
         if (!callout) return;
-        //apply metadata
 
-        const type = callout.dataset.callout;
+        //apply metadata
+        const type = callout.dataset.callout?.toLowerCase() || "note";
         const admonition = this.plugin.admonitions[type];
         if (!admonition) return;
+        if (callout.dataset.callout !== type) {
+            callout.dataset.callout = type;
+        }
 
         const titleEl = callout.querySelector<HTMLDivElement>(".callout-title");
         const content =


### PR DESCRIPTION
After the lowercase normalization migration (PR #371), notes with mixed-case callout syntax (e.g. > [!Test]) fail to apply custom admonition styling because data-callout preserves the original case while settings keys and CSS selectors are now lowercase.

Fixes #388